### PR TITLE
Fix oversized 3D text and clean up navbar styling

### DIFF
--- a/components/Main.tsx
+++ b/components/Main.tsx
@@ -148,8 +148,8 @@ const Main = ({ minimapState, setMinimapState }: MainProps) => {
           )}
           {!autoPilot && (
             <Billboard position={[-18, 2.3, 17]}>
-              <Text color="white" maxWidth={3} anchorX="left">
-                {`Se rundt:           venstreklikk/en finger\nPanorer:            høyreklikk/to fingre\nZoom:    scroll/klyp`}
+              <Text color="white" maxWidth={3} anchorX="left" anchorY="middle" fontSize={0.09} lineHeight={1.08}>
+                {`Se rundt: venstreklikk/en finger\nPanorer: høyreklikk/to fingre\nZoom: scroll/klyp`}
               </Text>
             </Billboard>
           )}

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -11,6 +11,12 @@ type NavbarProps = {
   setMinimapState: MinimapStateSetter;
 };
 
+const NAV_LINK_CLASSES =
+  'inline-block text-sm uppercase text-[#1f2937] border-b-2 border-transparent px-1 py-2 transition-colors hover:border-[#1f2937] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#1f2937] bg-transparent';
+
+const MOBILE_LINK_CLASSES =
+  'py-4 text-sm text-[#1f2937] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#1f2937] bg-transparent';
+
 const Navbar = ({ setMinimapState }: NavbarProps) => {
   const [navOpen, setNavOpen] = useState(false);
   const [shadow, setShadow] = useState(false);
@@ -69,39 +75,39 @@ const Navbar = ({ setMinimapState }: NavbarProps) => {
         <button
           type="button"
           onClick={() => setCamera('start')}
-          className="cursor-pointer focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#1f2937]"
+          className="cursor-pointer focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#1f2937] bg-transparent"
           aria-label="Gå til startposisjonen"
         >
           <Image src={NavImg} alt="Icon av Jens" height={60} width={150} />
         </button>
         <div>
-          <ul className="hidden md:flex">
-            <li className="ml-10 text-sm uppercase hover:border-b">
-              <button type="button" onClick={() => setCamera('about')} className="focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#1f2937]">
+          <ul className="hidden md:flex items-center">
+            <li className="ml-10">
+              <button type="button" onClick={() => setCamera('about')} className={NAV_LINK_CLASSES}>
                 Om meg
               </button>
             </li>
-            <li className="ml-10 text-sm uppercase hover:border-b">
-              <button type="button" onClick={() => setCamera('law')} className="focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#1f2937]">
+            <li className="ml-10">
+              <button type="button" onClick={() => setCamera('law')} className={NAV_LINK_CLASSES}>
                 Juss
               </button>
             </li>
-            <li className="ml-10 text-sm uppercase hover:border-b">
-              <button type="button" onClick={() => setCamera('tech')} className="focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#1f2937]">
+            <li className="ml-10">
+              <button type="button" onClick={() => setCamera('tech')} className={NAV_LINK_CLASSES}>
                 Teknologi
               </button>
             </li>
-            <li className="ml-10 text-sm uppercase hover:border-b">
-              <button type="button" onClick={() => setCamera('music')} className="focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#1f2937]">
+            <li className="ml-10">
+              <button type="button" onClick={() => setCamera('music')} className={NAV_LINK_CLASSES}>
                 Musikk
               </button>
             </li>
-            <li className="ml-10 text-sm uppercase hover:border-b">
+            <li className="ml-10">
               <a
                 href="https://www.linkedin.com/in/jens-andresen-osberg-2a09ba99/"
                 target="_blank"
                 rel="noreferrer"
-                className="focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#1f2937]"
+                className={NAV_LINK_CLASSES}
               >
                 Ta kontakt
               </a>
@@ -111,7 +117,7 @@ const Navbar = ({ setMinimapState }: NavbarProps) => {
             type="button"
             style={{ color: '#1f2937' }}
             onClick={() => setNavOpen(true)}
-            className="md:hidden focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#1f2937]"
+            className="md:hidden focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#1f2937] bg-transparent"
             aria-expanded={navOpen}
             aria-controls="mobile-navigation"
             aria-label="Åpne meny"
@@ -134,7 +140,7 @@ const Navbar = ({ setMinimapState }: NavbarProps) => {
               <button
                 type="button"
                 onClick={() => setCameraAndCloseNav('start')}
-                className="focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#1f2937]"
+                className="bg-transparent focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#1f2937]"
                 aria-label="Gå til startposisjonen"
               >
                 <Image src={NavImg} width={87} height={35} alt="Icon av Jens" />
@@ -152,53 +158,53 @@ const Navbar = ({ setMinimapState }: NavbarProps) => {
               <button
                 type="button"
                 onClick={() => setCameraAndCloseNav('start')}
-                className="w-full text-left focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#1f2937]"
+                className="w-full text-left text-[#1f2937] py-4 bg-transparent focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#1f2937]"
               >
-                <p className="w-[85%] md:w-[90%] py-4">Jurist og teknolog</p>
+                Jurist og teknolog
               </button>
             </div>
           </div>
           <div className="py-4 flex flex-col">
             <ul className="uppercase">
-              <li className="py-4 text-sm">
+              <li>
                 <button
                   type="button"
                   onClick={() => setCameraAndCloseNav('about')}
-                  className="focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#1f2937]"
+                  className={MOBILE_LINK_CLASSES}
                 >
                   Om meg
                 </button>
               </li>
-              <li className="py-4 text-sm">
+              <li>
                 <button
                   type="button"
                   onClick={() => setCameraAndCloseNav('law')}
-                  className="focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#1f2937]"
+                  className={MOBILE_LINK_CLASSES}
                 >
                   Juss
                 </button>
               </li>
-              <li className="py-4 text-sm">
+              <li>
                 <button
                   type="button"
                   onClick={() => setCameraAndCloseNav('tech')}
-                  className="focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#1f2937]"
+                  className={MOBILE_LINK_CLASSES}
                 >
                   Teknologi
                 </button>
               </li>
-              <li className="py-4 text-sm">
+              <li>
                 <button
                   type="button"
                   onClick={() => setCameraAndCloseNav('music')}
-                  className="focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#1f2937]"
+                  className={MOBILE_LINK_CLASSES}
                 >
                   Musikk
                 </button>
               </li>
             </ul>
             <div className="pt-40">
-              <p className="uppercase tracking-widest text-[#561e5]">Ta kontakt!</p>
+              <p className="uppercase tracking-widest text-[#5651e5]">Ta kontakt!</p>
               <div className="flex items-center justify-between my-4 w-full sm:w-[80%]">
                 <a
                   href="https://www.linkedin.com/in/jens-andresen-osberg-2a09ba99/"

--- a/components/TextComponents.tsx
+++ b/components/TextComponents.tsx
@@ -1,34 +1,38 @@
 import { Billboard, Text } from '@react-three/drei';
 
+const TEXT_PROPS = {
+  fontSize: 0.22,
+  lineHeight: 1.25,
+} as const;
+
 const TextComponents = () => (
   <group>
     <Billboard position={[-8, 1.5, 12]}>
-      <Text color="white" maxWidth={2}>
+      <Text color="white" maxWidth={2.2} anchorY="middle" {...TEXT_PROPS}>
         {`Jurist og teknolog.\nJobber som seniorrådgiver om dagen.\nSpiller gitar og koder om natten.`}
       </Text>
     </Billboard>
 
     <Billboard position={[3.5, 5, -1]}>
-      <Text color="white" maxWidth={2}>
+      <Text color="white" maxWidth={2.4} anchorY="middle" {...TEXT_PROPS}>
         Jurist med master i rettsvitenskap fra UiO. Jobber med EU-juss, særlig personvern. Ekspert på Schrems II og bruk av
         skytjenester.
       </Text>
     </Billboard>
 
     <Billboard position={[10, 2.65, 10]}>
-      <Text color="yellow" maxWidth={2}>
-        {`Teknolog med bachelor i programmering og systemarkitektur fra UiO.\n\nSpesialisert på nettverk- og
-kommunikasjonssikkerhet.`}
+      <Text color="yellow" maxWidth={2.2} anchorY="middle" {...TEXT_PROPS}>
+        {`Teknolog med bachelor i programmering og systemarkitektur fra UiO.\n\nSpesialisert på nettverk- og kommunikasjonssikkerhet.`}
       </Text>
     </Billboard>
     <Billboard position={[10, 1.75, 11]}>
-      <Text color="yellow" maxWidth={1}>
+      <Text color="yellow" maxWidth={1.4} anchorY="middle" {...TEXT_PROPS}>
         {`Denne siden er laget med:\n- Next.js\n- React\n- Tailwind\n- Three.js\n- Blender`}
       </Text>
     </Billboard>
 
     <Billboard position={[-5, 4, -4.5]}>
-      <Text color="white" maxWidth={1.2} anchorX="left">
+      <Text color="white" maxWidth={1.6} anchorX="left" anchorY="middle" {...TEXT_PROPS}>
         {`Spiller gitar i bandet Gete.\nVi er der du strømmer musikk!\n\nDu kan også klikke på radioen i tårnet.`}
       </Text>
     </Billboard>

--- a/components/TextComponents.tsx
+++ b/components/TextComponents.tsx
@@ -1,8 +1,8 @@
 import { Billboard, Text } from '@react-three/drei';
 
 const TEXT_PROPS = {
-  fontSize: 0.18,
-  lineHeight: 1.2,
+  fontSize: 0.14,
+  lineHeight: 1.15,
 } as const;
 
 const TextComponents = () => (

--- a/components/TextComponents.tsx
+++ b/components/TextComponents.tsx
@@ -1,8 +1,8 @@
 import { Billboard, Text } from '@react-three/drei';
 
 const TEXT_PROPS = {
-  fontSize: 0.13,
-  lineHeight: 1.12,
+  fontSize: 0.09,
+  lineHeight: 1.08,
 } as const;
 
 const TextComponents = () => (

--- a/components/TextComponents.tsx
+++ b/components/TextComponents.tsx
@@ -1,8 +1,8 @@
 import { Billboard, Text } from '@react-three/drei';
 
 const TEXT_PROPS = {
-  fontSize: 0.14,
-  lineHeight: 1.15,
+  fontSize: 0.13,
+  lineHeight: 1.12,
 } as const;
 
 const TextComponents = () => (

--- a/components/TextComponents.tsx
+++ b/components/TextComponents.tsx
@@ -1,38 +1,38 @@
 import { Billboard, Text } from '@react-three/drei';
 
 const TEXT_PROPS = {
-  fontSize: 0.22,
-  lineHeight: 1.25,
+  fontSize: 0.18,
+  lineHeight: 1.2,
 } as const;
 
 const TextComponents = () => (
   <group>
     <Billboard position={[-8, 1.5, 12]}>
-      <Text color="white" maxWidth={2.2} anchorY="middle" {...TEXT_PROPS}>
+      <Text color="white" maxWidth={2} anchorY="middle" {...TEXT_PROPS}>
         {`Jurist og teknolog.\nJobber som seniorrådgiver om dagen.\nSpiller gitar og koder om natten.`}
       </Text>
     </Billboard>
 
     <Billboard position={[3.5, 5, -1]}>
-      <Text color="white" maxWidth={2.4} anchorY="middle" {...TEXT_PROPS}>
+      <Text color="white" maxWidth={2} anchorY="middle" {...TEXT_PROPS}>
         Jurist med master i rettsvitenskap fra UiO. Jobber med EU-juss, særlig personvern. Ekspert på Schrems II og bruk av
         skytjenester.
       </Text>
     </Billboard>
 
     <Billboard position={[10, 2.65, 10]}>
-      <Text color="yellow" maxWidth={2.2} anchorY="middle" {...TEXT_PROPS}>
+      <Text color="yellow" maxWidth={2} anchorY="middle" {...TEXT_PROPS}>
         {`Teknolog med bachelor i programmering og systemarkitektur fra UiO.\n\nSpesialisert på nettverk- og kommunikasjonssikkerhet.`}
       </Text>
     </Billboard>
     <Billboard position={[10, 1.75, 11]}>
-      <Text color="yellow" maxWidth={1.4} anchorY="middle" {...TEXT_PROPS}>
+      <Text color="yellow" maxWidth={1} anchorY="middle" {...TEXT_PROPS}>
         {`Denne siden er laget med:\n- Next.js\n- React\n- Tailwind\n- Three.js\n- Blender`}
       </Text>
     </Billboard>
 
     <Billboard position={[-5, 4, -4.5]}>
-      <Text color="white" maxWidth={1.6} anchorX="left" anchorY="middle" {...TEXT_PROPS}>
+      <Text color="white" maxWidth={1.2} anchorX="left" anchorY="middle" {...TEXT_PROPS}>
         {`Spiller gitar i bandet Gete.\nVi er der du strømmer musikk!\n\nDu kan også klikke på radioen i tårnet.`}
       </Text>
     </Billboard>

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "typescript": "^5.9.3"
       },
       "engines": {
-        "node": "22.x"
+        "node": ">=18 <25"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "engines": {
-    "node": "22.x"
+    "node": ">=18 <25"
   },
   "scripts": {
     "dev": "next dev",

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -2,41 +2,36 @@
 @tailwind components;
 @tailwind utilities;
 
-
 @import url('https://fonts.googleapis.com/css2?family=Raleway:wght@100;200;300;400;500;600;700;800;900&display=swap');
 
 html {
-    scroll-behavior: smooth;
-    font-family: 'Raleway', sans-serif;
+  scroll-behavior: smooth;
+  font-family: 'Raleway', sans-serif;
 }
 
 @layer base {
-    body {
-        @apply bg-[#ecf0f3] text-[#1f2937] tracking-wide
-    }
+  body {
+    @apply bg-[#ecf0f3] text-[#1f2937] tracking-wide;
+  }
 
-    h1,
-    h2,
-    h3,
-    h4,
-    h5,
-    h6 {
-        @apply font-bold
-    }
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    @apply font-bold;
+  }
 
-    h1 {
-        @apply text-4xl sm:text-5xl md:text-6xl font-[Raleway]
-    }
+  h1 {
+    @apply text-4xl sm:text-5xl md:text-6xl font-[Raleway];
+  }
 
-    h2 {
-        @apply text-3xl sm:text-4xl
-    }
+  h2 {
+    @apply text-3xl sm:text-4xl;
+  }
 
-    li {
-        @apply cursor-pointer
-    }
-
-    button {
-        @apply shadow-xl shadow-gray-400 rounded-xl uppercase bg-gradient-to-r from-[#5651e5] to-[#709dff] text-white
-    }
+  li {
+    @apply cursor-pointer;
+  }
 }


### PR DESCRIPTION
## Summary
- add shared sizing props to the drei text billboards to restore the original layout
- remove the global gradient button styling and restyle the navbar links for consistent appearance
- relax the Node.js engine requirement and refresh the lockfile

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f23e9013788328b5c04dad8ae32257