### PR TITLE
Add minimap help dialog and UI toggle

### DIFF
--- a/components/Main.tsx
+++ b/components/Main.tsx
@@ -209,6 +209,7 @@ const Main = ({ minimapState, setMinimapState }: MainProps) => {
         }}
         showMap={showMap}
         setShowMap={setShowMap}
+        setMinimapState={setMinimapState}
       />
       {!minimapHelpOpen && (
         <button

--- a/components/MinimapHelpDialog.tsx
+++ b/components/MinimapHelpDialog.tsx
@@ -30,14 +30,16 @@ export function MinimapHelpDialog({
           <div className="aspect-[5/4] w-full">
             <Canvas
               style={{ width: '100%', height: '100%' }}
-              camera={{ position: [0.08, 0.72, 1.45], fov: 26 }}
+              camera={{ position: [0.02, 1.08, 1.88], fov: 34 }}
               dpr={[1, 2]}
             >
               <color attach="background" args={['#130805']} />
-              <ambientLight intensity={0.7} />
-              <directionalLight position={[2.2, 3.2, 4]} intensity={1} />
+              <ambientLight intensity={0.85} />
+              <directionalLight position={[1.8, 2.6, 3.4]} intensity={0.85} />
+              <pointLight position={[0.6, 1.6, 1.35]} intensity={1.8} color="#ffd8a8" distance={5} />
+              <pointLight position={[-0.7, 1.4, 1.45]} intensity={1.4} color="#ffe7c2" distance={5} />
               <Suspense fallback={null}>
-                <group rotation={[-0.3, 0.32, 0]} position={[0.02, -0.16, 0.04]} scale={0.92}>
+                <group rotation={[-0.24, 0.28, 0.02]} position={[0.01, -0.24, 0.08]} scale={0.78}>
                   <MinimapInteractive
                     setMinimapState={setMinimapState}
                     onRegionSelect={() => onOpenChange(false)}

--- a/components/MinimapHelpDialog.tsx
+++ b/components/MinimapHelpDialog.tsx
@@ -34,18 +34,17 @@ export function MinimapHelpDialog({
         <DialogHeader>
           <DialogTitle>Få oversikt med minimappet</DialogTitle>
           <DialogDescription>
-            Minimappet lar deg hoppe mellom områdene på øya. Du kan slå det av når du vil utforske på egenhånd, og slå det på igjen
-            når du trenger oversikten.
+            Hopp raskt mellom områdene ved å trykke på minimappet. Du kan slå det av når du vil styre kameraet selv.
           </DialogDescription>
         </DialogHeader>
         <div className="flex flex-col gap-4">
-          <div className="overflow-hidden rounded-xl border border-white/10 bg-black/40">
-            <Canvas camera={{ position: [0, 1.4, 3.2], fov: 30 }} dpr={[1, 2]}>
+          <div className="h-64 overflow-hidden rounded-xl border border-white/10 bg-black/40 sm:h-72">
+            <Canvas camera={{ position: [0, 1.05, 2.2], fov: 32 }} dpr={[1, 2]}>
               <color attach="background" args={['#050505']} />
               <ambientLight intensity={0.6} />
               <directionalLight position={[2, 3, 4]} intensity={0.9} />
               <Suspense fallback={null}>
-                <group rotation={[-0.3, 0.35, 0]} position={[0, -0.5, 0]} scale={0.4}>
+                <group rotation={[-0.32, 0.35, 0]} position={[0, -0.34, 0]} scale={0.58}>
                   <MinimapInteractive
                     setMinimapState={setMinimapState}
                     onRegionSelect={() => onOpenChange(false)}
@@ -55,12 +54,7 @@ export function MinimapHelpDialog({
             </Canvas>
           </div>
           <div className="rounded-lg bg-white/5 p-4 text-sm leading-relaxed text-white/80">
-            <p className="font-semibold text-white">Tips</p>
-            <ul className="mt-2 space-y-1 list-disc pl-5">
-              <li>Trykk på de ulike områdene for å flytte kameraet automatisk.</li>
-              <li>Slå av minimappet når du vil styre kameraet fritt.</li>
-              <li>Du kan alltid åpne denne hjelpen igjen fra knappen nederst på siden.</li>
-            </ul>
+            <p>Trykk på et område for å flytte kameraet dit, eller slå av minimappet for fri utforsking.</p>
           </div>
         </div>
         <DialogFooter>

--- a/components/MinimapHelpDialog.tsx
+++ b/components/MinimapHelpDialog.tsx
@@ -25,21 +25,32 @@ export function MinimapHelpDialog({
 }: MinimapHelpDialogProps) {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="overflow-hidden border-white/20 bg-[radial-gradient(circle_at_top,_rgba(255,147,88,0.32),_rgba(9,6,17,0.96))] p-0">
+      <DialogContent className="sm:max-w-2xl overflow-hidden border-white/20 bg-[radial-gradient(circle_at_top,_rgba(255,147,88,0.32),_rgba(9,6,17,0.96))] p-0">
         <div className="relative">
-          <div className="aspect-[5/4] w-full">
+          <div className="relative h-[min(55vh,460px)] w-full">
             <Canvas
+              shadows
               style={{ width: '100%', height: '100%' }}
-              camera={{ position: [0.02, 1.08, 1.88], fov: 34 }}
+              camera={{ position: [0.22, 1.08, 1.92], fov: 36 }}
               dpr={[1, 2]}
             >
               <color attach="background" args={['#130805']} />
-              <ambientLight intensity={0.85} />
-              <directionalLight position={[1.8, 2.6, 3.4]} intensity={0.85} />
-              <pointLight position={[0.6, 1.6, 1.35]} intensity={1.8} color="#ffd8a8" distance={5} />
-              <pointLight position={[-0.7, 1.4, 1.45]} intensity={1.4} color="#ffe7c2" distance={5} />
+              <ambientLight intensity={0.7} />
+              <hemisphereLight intensity={0.35} groundColor="#1f0b07" color="#ffefde" />
+              <spotLight
+                position={[0.32, 2.18, 1.42]}
+                angle={0.9}
+                penumbra={0.4}
+                intensity={0.75}
+                color="#ffd4a1"
+                distance={7}
+                castShadow
+              />
+              <pointLight position={[-0.82, 1.58, 1.58]} intensity={1.65} color="#ffb973" distance={6} />
+              <pointLight position={[0.96, 1.72, 1.32]} intensity={1.35} color="#ffcfa1" distance={6} />
+              <pointLight position={[0.18, 0.74, -0.82]} intensity={0.8} color="#ffe6c7" distance={6} />
               <Suspense fallback={null}>
-                <group rotation={[-0.24, 0.28, 0.02]} position={[0.01, -0.24, 0.08]} scale={0.78}>
+                <group rotation={[-0.58, 0.58, 0.12]} position={[0.06, -0.32, 0.08]} scale={0.92}>
                   <MinimapInteractive
                     setMinimapState={setMinimapState}
                     onRegionSelect={() => onOpenChange(false)}
@@ -48,7 +59,7 @@ export function MinimapHelpDialog({
               </Suspense>
             </Canvas>
           </div>
-          <div className="pointer-events-none absolute inset-0 bg-gradient-to-b from-white/15 via-transparent to-transparent" />
+          <div className="pointer-events-none absolute inset-0 bg-gradient-to-b from-white/20 via-transparent to-transparent" />
         </div>
         <div className="space-y-5 p-6">
           <DialogHeader className="gap-3">

--- a/components/MinimapHelpDialog.tsx
+++ b/components/MinimapHelpDialog.tsx
@@ -1,5 +1,4 @@
 import { Suspense } from 'react';
-import type { Dispatch, SetStateAction } from 'react';
 import { Canvas } from '@react-three/fiber';
 
 import {
@@ -16,35 +15,29 @@ import type { MinimapStateSetter } from '../types/minimap';
 interface MinimapHelpDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  showMap: boolean;
-  setShowMap: Dispatch<SetStateAction<boolean>>;
   setMinimapState: MinimapStateSetter;
 }
 
 export function MinimapHelpDialog({
   open,
   onOpenChange,
-  showMap,
-  setShowMap,
   setMinimapState,
 }: MinimapHelpDialogProps) {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle>Få oversikt med minimappet</DialogTitle>
-          <DialogDescription>
-            Hopp raskt mellom områdene ved å trykke på minimappet. Du kan slå det av når du vil styre kameraet selv.
-          </DialogDescription>
-        </DialogHeader>
-        <div className="flex flex-col gap-4">
-          <div className="h-64 overflow-hidden rounded-xl border border-white/10 bg-black/40 sm:h-72">
-            <Canvas camera={{ position: [0, 1.05, 2.2], fov: 32 }} dpr={[1, 2]}>
-              <color attach="background" args={['#050505']} />
-              <ambientLight intensity={0.6} />
-              <directionalLight position={[2, 3, 4]} intensity={0.9} />
+      <DialogContent className="overflow-hidden border-white/20 bg-[radial-gradient(circle_at_top,_rgba(255,147,88,0.32),_rgba(9,6,17,0.96))] p-0">
+        <div className="relative">
+          <div className="aspect-[5/4] w-full">
+            <Canvas
+              style={{ width: '100%', height: '100%' }}
+              camera={{ position: [0.08, 0.72, 1.45], fov: 26 }}
+              dpr={[1, 2]}
+            >
+              <color attach="background" args={['#130805']} />
+              <ambientLight intensity={0.7} />
+              <directionalLight position={[2.2, 3.2, 4]} intensity={1} />
               <Suspense fallback={null}>
-                <group rotation={[-0.32, 0.35, 0]} position={[0, -0.34, 0]} scale={0.58}>
+                <group rotation={[-0.3, 0.32, 0]} position={[0.02, -0.16, 0.04]} scale={0.92}>
                   <MinimapInteractive
                     setMinimapState={setMinimapState}
                     onRegionSelect={() => onOpenChange(false)}
@@ -53,26 +46,28 @@ export function MinimapHelpDialog({
               </Suspense>
             </Canvas>
           </div>
-          <div className="rounded-lg bg-white/5 p-4 text-sm leading-relaxed text-white/80">
-            <p>Trykk på et område for å flytte kameraet dit, eller slå av minimappet for fri utforsking.</p>
-          </div>
+          <div className="pointer-events-none absolute inset-0 bg-gradient-to-b from-white/15 via-transparent to-transparent" />
         </div>
-        <DialogFooter>
-          <button
-            type="button"
-            onClick={() => setShowMap((value) => !value)}
-            className="inline-flex items-center justify-center rounded-full bg-orange-500 px-4 py-2 text-sm font-semibold text-black transition hover:bg-orange-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange-300 focus-visible:ring-offset-2 focus-visible:ring-offset-neutral-900"
-          >
-            {showMap ? 'Skjul minimappet' : 'Vis minimappet'}
-          </button>
-          <button
-            type="button"
-            onClick={() => onOpenChange(false)}
-            className="inline-flex items-center justify-center rounded-full border border-white/20 px-4 py-2 text-sm font-semibold text-white transition hover:border-white/40 hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/40"
-          >
-            Lukk
-          </button>
-        </DialogFooter>
+        <div className="space-y-5 p-6">
+          <DialogHeader className="gap-3">
+            <DialogTitle>Hopp mellom øyene</DialogTitle>
+            <DialogDescription>
+              Trykk på et område i minimappet for å reise dit. Når dialogen lukkes kan du styre kameraet fritt.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="rounded-lg border border-white/15 bg-black/30 p-4 text-sm leading-relaxed text-white/80">
+            <p>Tips: Velg «Styr kameraet selv» for fri utforsking, eller klikk på øynene for å hoppe direkte til dem.</p>
+          </div>
+          <DialogFooter className="justify-end pt-1">
+            <button
+              type="button"
+              onClick={() => onOpenChange(false)}
+              className="inline-flex items-center justify-center rounded-full border border-white/40 px-5 py-2 text-sm font-semibold text-white transition hover:border-white/60 hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
+            >
+              Lukk
+            </button>
+          </DialogFooter>
+        </div>
       </DialogContent>
     </Dialog>
   );

--- a/components/MinimapHelpDialog.tsx
+++ b/components/MinimapHelpDialog.tsx
@@ -10,16 +10,24 @@ import {
   DialogHeader,
   DialogTitle,
 } from './ui/dialog';
-import { MinimapThumbnail } from './MinimapThumbnail';
+import { MinimapInteractive } from './MinimapInteractive';
+import type { MinimapStateSetter } from '../types/minimap';
 
 interface MinimapHelpDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   showMap: boolean;
   setShowMap: Dispatch<SetStateAction<boolean>>;
+  setMinimapState: MinimapStateSetter;
 }
 
-export function MinimapHelpDialog({ open, onOpenChange, showMap, setShowMap }: MinimapHelpDialogProps) {
+export function MinimapHelpDialog({
+  open,
+  onOpenChange,
+  showMap,
+  setShowMap,
+  setMinimapState,
+}: MinimapHelpDialogProps) {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent>
@@ -32,12 +40,16 @@ export function MinimapHelpDialog({ open, onOpenChange, showMap, setShowMap }: M
         </DialogHeader>
         <div className="flex flex-col gap-4">
           <div className="overflow-hidden rounded-xl border border-white/10 bg-black/40">
-            <Canvas camera={{ position: [0, 0, 2.5], fov: 35 }} dpr={[1, 2]}>
-              <ambientLight intensity={0.7} />
-              <directionalLight position={[2, 3, 4]} intensity={0.8} />
+            <Canvas camera={{ position: [0, 1.4, 3.2], fov: 30 }} dpr={[1, 2]}>
+              <color attach="background" args={['#050505']} />
+              <ambientLight intensity={0.6} />
+              <directionalLight position={[2, 3, 4]} intensity={0.9} />
               <Suspense fallback={null}>
-                <group rotation={[0.15, 0.4, 0]} scale={2} position={[0, -0.3, 0]}>
-                  <MinimapThumbnail />
+                <group rotation={[-0.3, 0.35, 0]} position={[0, -0.5, 0]} scale={0.4}>
+                  <MinimapInteractive
+                    setMinimapState={setMinimapState}
+                    onRegionSelect={() => onOpenChange(false)}
+                  />
                 </group>
               </Suspense>
             </Canvas>

--- a/components/MinimapHelpDialog.tsx
+++ b/components/MinimapHelpDialog.tsx
@@ -1,0 +1,73 @@
+import { Suspense } from 'react';
+import type { Dispatch, SetStateAction } from 'react';
+import { Canvas } from '@react-three/fiber';
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from './ui/dialog';
+import { MinimapThumbnail } from './MinimapThumbnail';
+
+interface MinimapHelpDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  showMap: boolean;
+  setShowMap: Dispatch<SetStateAction<boolean>>;
+}
+
+export function MinimapHelpDialog({ open, onOpenChange, showMap, setShowMap }: MinimapHelpDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Få oversikt med minimappet</DialogTitle>
+          <DialogDescription>
+            Minimappet lar deg hoppe mellom områdene på øya. Du kan slå det av når du vil utforske på egenhånd, og slå det på igjen
+            når du trenger oversikten.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="flex flex-col gap-4">
+          <div className="overflow-hidden rounded-xl border border-white/10 bg-black/40">
+            <Canvas camera={{ position: [0, 0, 2.5], fov: 35 }} dpr={[1, 2]}>
+              <ambientLight intensity={0.7} />
+              <directionalLight position={[2, 3, 4]} intensity={0.8} />
+              <Suspense fallback={null}>
+                <group rotation={[0.15, 0.4, 0]} scale={2} position={[0, -0.3, 0]}>
+                  <MinimapThumbnail />
+                </group>
+              </Suspense>
+            </Canvas>
+          </div>
+          <div className="rounded-lg bg-white/5 p-4 text-sm leading-relaxed text-white/80">
+            <p className="font-semibold text-white">Tips</p>
+            <ul className="mt-2 space-y-1 list-disc pl-5">
+              <li>Trykk på de ulike områdene for å flytte kameraet automatisk.</li>
+              <li>Slå av minimappet når du vil styre kameraet fritt.</li>
+              <li>Du kan alltid åpne denne hjelpen igjen fra knappen nederst på siden.</li>
+            </ul>
+          </div>
+        </div>
+        <DialogFooter>
+          <button
+            type="button"
+            onClick={() => setShowMap((value) => !value)}
+            className="inline-flex items-center justify-center rounded-full bg-orange-500 px-4 py-2 text-sm font-semibold text-black transition hover:bg-orange-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange-300 focus-visible:ring-offset-2 focus-visible:ring-offset-neutral-900"
+          >
+            {showMap ? 'Skjul minimappet' : 'Vis minimappet'}
+          </button>
+          <button
+            type="button"
+            onClick={() => onOpenChange(false)}
+            className="inline-flex items-center justify-center rounded-full border border-white/20 px-4 py-2 text-sm font-semibold text-white transition hover:border-white/40 hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/40"
+          >
+            Lukk
+          </button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/MinimapInteractive.tsx
+++ b/components/MinimapInteractive.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from 'react';
 import { useGLTF } from '@react-three/drei';
 import type { ThreeElements } from '@react-three/fiber';
+import { Vector3 } from 'three';
 
 import type { CameraTarget, MinimapStateSetter } from '../types/minimap';
 import { triggerMinimapTarget } from '../types/minimap';
@@ -46,7 +47,15 @@ const scaleWithHover = (
     return scale.map((value) => value * multiplier) as typeof scale;
   }
 
-  return scale * multiplier;
+  if (typeof scale === 'number') {
+    return scale * multiplier;
+  }
+
+  if (scale instanceof Vector3) {
+    return scale.clone().multiplyScalar(multiplier);
+  }
+
+  return scale;
 };
 
 const setCursor = (cursor: string) => {

--- a/components/MinimapInteractive.tsx
+++ b/components/MinimapInteractive.tsx
@@ -1,4 +1,6 @@
+import { useMemo, useState } from 'react';
 import { useGLTF } from '@react-three/drei';
+import type { ThreeElements } from '@react-three/fiber';
 
 import type { CameraTarget, MinimapStateSetter } from '../types/minimap';
 import { triggerMinimapTarget } from '../types/minimap';
@@ -7,23 +9,96 @@ import type { MinimapGLTF } from './models';
 
 type MinimapProps = {
   setMinimapState: MinimapStateSetter;
+  onRegionSelect?: () => void;
 };
 
 const handleSelection = (
   setMinimapState: MinimapStateSetter,
   target: CameraTarget,
   autoPilot: boolean,
+  onRegionSelect?: () => void,
 ) => {
   triggerMinimapTarget(setMinimapState, target, autoPilot);
+  onRegionSelect?.();
 };
 
-export function MinimapInteractive({ setMinimapState }: MinimapProps) {
+type MeshProps = ThreeElements['mesh'];
+
+interface InteractiveMeshProps extends MeshProps {
+  onSelect: () => void;
+  hoverScale?: number;
+}
+
+const DEFAULT_HOVER_SCALE = 1.12;
+
+const scaleWithHover = (
+  scale: InteractiveMeshProps['scale'],
+  hoverScale: number,
+  hovered: boolean,
+) => {
+  if (scale === undefined) {
+    return scale;
+  }
+
+  const multiplier = hovered ? hoverScale : 1;
+
+  if (Array.isArray(scale)) {
+    return scale.map((value) => value * multiplier) as typeof scale;
+  }
+
+  return scale * multiplier;
+};
+
+const setCursor = (cursor: string) => {
+  if (typeof document === 'undefined') {
+    return;
+  }
+
+  document.body.style.cursor = cursor;
+};
+
+const InteractiveMesh = ({
+  onSelect,
+  hoverScale = DEFAULT_HOVER_SCALE,
+  scale,
+  ...props
+}: InteractiveMeshProps) => {
+  const [hovered, setHovered] = useState(false);
+
+  const resolvedScale = useMemo(
+    () => scaleWithHover(scale, hoverScale, hovered),
+    [hoverScale, hovered, scale],
+  );
+
+  return (
+    <mesh
+      {...props}
+      scale={resolvedScale}
+      onClick={(event) => {
+        event.stopPropagation();
+        onSelect();
+      }}
+      onPointerOver={(event) => {
+        event.stopPropagation();
+        setHovered(true);
+        setCursor('pointer');
+      }}
+      onPointerOut={(event) => {
+        event.stopPropagation();
+        setHovered(false);
+        setCursor('');
+      }}
+    />
+  );
+};
+
+export function MinimapInteractive({ setMinimapState, onRegionSelect }: MinimapProps) {
   // @ts-expect-error drei returns GLTF & ObjectMap; gltfjsx provides refined typings for our asset
   const { nodes, materials } = useGLTF('/minimap.glb') as MinimapGLTF;
 
   return (
     <group scale={4} dispose={null}>
-      <mesh
+      <InteractiveMesh
         castShadow
         receiveShadow
         geometry={nodes.Om_meg.geometry}
@@ -31,9 +106,9 @@ export function MinimapInteractive({ setMinimapState }: MinimapProps) {
         position={[0.03, -0.02, 0.03]}
         rotation={[1.98, -0.27, 0.36]}
         scale={0.03}
-        onClick={() => handleSelection(setMinimapState, 'about', true)}
+        onSelect={() => handleSelection(setMinimapState, 'about', true, onRegionSelect)}
       />
-      <mesh
+      <InteractiveMesh
         castShadow
         receiveShadow
         geometry={nodes.Juss.geometry}
@@ -41,9 +116,9 @@ export function MinimapInteractive({ setMinimapState }: MinimapProps) {
         position={[-0.11, 0.1, -0.03]}
         rotation={[1.78, 0, 0.21]}
         scale={0.05}
-        onClick={() => handleSelection(setMinimapState, 'law', true)}
+        onSelect={() => handleSelection(setMinimapState, 'law', true, onRegionSelect)}
       />
-      <mesh
+      <InteractiveMesh
         castShadow
         receiveShadow
         geometry={nodes.Musikk.geometry}
@@ -51,9 +126,9 @@ export function MinimapInteractive({ setMinimapState }: MinimapProps) {
         position={[-0.17, 0, 0]}
         rotation={[1.89, 0.35, -0.22]}
         scale={0.04}
-        onClick={() => handleSelection(setMinimapState, 'music', true)}
+        onSelect={() => handleSelection(setMinimapState, 'music', true, onRegionSelect)}
       />
-      <mesh
+      <InteractiveMesh
         castShadow
         receiveShadow
         geometry={nodes.Teknologi.geometry}
@@ -61,9 +136,9 @@ export function MinimapInteractive({ setMinimapState }: MinimapProps) {
         position={[0.02, 0.1, -0.02]}
         rotation={[1.83, 0.02, 0.19]}
         scale={0.04}
-        onClick={() => handleSelection(setMinimapState, 'tech', true)}
+        onSelect={() => handleSelection(setMinimapState, 'tech', true, onRegionSelect)}
       />
-      <mesh
+      <InteractiveMesh
         castShadow
         receiveShadow
         geometry={nodes.Styr_kameraet_selv.geometry}
@@ -71,42 +146,47 @@ export function MinimapInteractive({ setMinimapState }: MinimapProps) {
         position={[-0.16, -0.05, 0.02]}
         rotation={[1.08, 0.11, 0.16]}
         scale={0.02}
-        onClick={() => handleSelection(setMinimapState, 'start', false)}
+        onSelect={() => handleSelection(setMinimapState, 'start', false, onRegionSelect)}
       />
-      <mesh
+      <InteractiveMesh
         castShadow
         receiveShadow
         geometry={nodes.Om_meg_kart.geometry}
         material={materials.kartutsnitt}
-        onClick={() => handleSelection(setMinimapState, 'about', true)}
+        hoverScale={1.02}
+        onSelect={() => handleSelection(setMinimapState, 'about', true, onRegionSelect)}
       />
-      <mesh
+      <InteractiveMesh
         castShadow
         receiveShadow
         geometry={nodes.Teknologi_kart.geometry}
         material={materials.kartutsnitt}
-        onClick={() => handleSelection(setMinimapState, 'tech', true)}
+        hoverScale={1.02}
+        onSelect={() => handleSelection(setMinimapState, 'tech', true, onRegionSelect)}
       />
-      <mesh
+      <InteractiveMesh
         castShadow
         receiveShadow
         geometry={nodes.Juss_kart.geometry}
         material={materials.kartutsnitt}
-        onClick={() => handleSelection(setMinimapState, 'law', true)}
+        hoverScale={1.02}
+        onSelect={() => handleSelection(setMinimapState, 'law', true, onRegionSelect)}
       />
-      <mesh
+      <InteractiveMesh
         castShadow
         receiveShadow
         geometry={nodes.Musikk_kart.geometry}
         material={materials.kartutsnitt}
-        onClick={() => handleSelection(setMinimapState, 'music', true)}
+        hoverScale={1.02}
+        onSelect={() => handleSelection(setMinimapState, 'music', true, onRegionSelect)}
       />
-      <mesh
+      <InteractiveMesh
         castShadow
         receiveShadow
         geometry={nodes.Styr_kamera_kart.geometry}
         material={materials.kartutsnitt}
-        onClick={() => handleSelection(setMinimapState, 'start', false)}
+        hoverScale={1.02}
+        onSelect={() => handleSelection(setMinimapState, 'start', false, onRegionSelect)}
       />
     </group>
   );

--- a/components/MinimapOverlay.tsx
+++ b/components/MinimapOverlay.tsx
@@ -1,10 +1,8 @@
 import { useMemo } from 'react';
-import type { Dispatch, SetStateAction } from 'react';
-import { Billboard, Text } from '@react-three/drei';
+import { Billboard } from '@react-three/drei';
 
 import type { Vector3Tuple } from 'three';
 
-import { MinimapThumbnail } from './MinimapThumbnail';
 import { MinimapInteractive } from './MinimapInteractive';
 import type { CameraTarget, MinimapState, MinimapStateSetter } from '../types/minimap';
 
@@ -12,59 +10,34 @@ const DEFAULT_MAP_POSITION: Vector3Tuple = [-18, 4, 18];
 const DEFAULT_LIGHT_POSITION: Vector3Tuple = [-18.2, 4.5, 18];
 
 const MAP_LAYOUT: Record<CameraTarget, {
-  textPosition: Vector3Tuple;
-  thumbPosition: Vector3Tuple;
   mapPosition: Vector3Tuple;
   lightPosition: Vector3Tuple;
-  textSize: number;
-  showToggle: boolean;
 }> = {
   start: {
-    textPosition: [-19.32, 4.1, 19.2] as Vector3Tuple,
-    thumbPosition: [-19, 4, 19.4] as Vector3Tuple,
     mapPosition: [-18, 4, 18] as Vector3Tuple,
     lightPosition: [-18.2, 4.5, 18] as Vector3Tuple,
-    textSize: 0.05,
-    showToggle: false,
   },
   about: {
-    textPosition: [-9.5, 1.27, 12.1] as Vector3Tuple,
-    thumbPosition: [-10, 1.82, 12.8] as Vector3Tuple,
     mapPosition: [-8.8, 2, 12] as Vector3Tuple,
     lightPosition: [-9, 2.4, 12] as Vector3Tuple,
-    textSize: 0.08,
-    showToggle: true,
   },
   law: {
-    textPosition: [1.4, 3.75, -3.7] as Vector3Tuple,
-    thumbPosition: [0.92, 4.2, -3.75] as Vector3Tuple,
     mapPosition: [2.25, 4.8, -2.5] as Vector3Tuple,
     lightPosition: [2.1, 5.3, -2.5] as Vector3Tuple,
-    textSize: 0.06,
-    showToggle: true,
   },
   tech: {
-    textPosition: [6.1, 1.57, 11.35] as Vector3Tuple,
-    thumbPosition: [6.3, 1.57, 11.74] as Vector3Tuple,
     mapPosition: [7.2, 2.5, 11] as Vector3Tuple,
     lightPosition: [7, 3, 11] as Vector3Tuple,
-    textSize: 0.07,
-    showToggle: true,
   },
   music: {
-    textPosition: [-5, 3, -4.5] as Vector3Tuple,
-    thumbPosition: [-4.8, 3.8, -3.4] as Vector3Tuple,
     mapPosition: [-4.8, 4.4, -4] as Vector3Tuple,
     lightPosition: [-5, 4.6, -3.9] as Vector3Tuple,
-    textSize: 0.1,
-    showToggle: true,
   },
 };
 
 type MinimapOverlayProps = {
   cameraPosition: CameraTarget;
   showMap: boolean;
-  toggleMap: Dispatch<SetStateAction<boolean>>;
   minimapState: MinimapState;
   setMinimapState: MinimapStateSetter;
 };
@@ -72,7 +45,6 @@ type MinimapOverlayProps = {
 const MinimapOverlay = ({
   cameraPosition,
   showMap,
-  toggleMap,
   minimapState,
   setMinimapState,
 }: MinimapOverlayProps) => {
@@ -91,18 +63,6 @@ const MinimapOverlay = ({
         </Billboard>
         <pointLight color="orange" intensity={0.8} position={lightPosition} distance={2} />
       </group>
-      {layout.showToggle && (
-        <group onClick={() => toggleMap((value) => !value)}>
-          <Billboard position={layout.textPosition}>
-            <Text color="white" maxWidth={2} fontSize={layout.textSize}>
-              {`Trykk her for å\nskru av og på kartet:`}
-            </Text>
-          </Billboard>
-          <Billboard position={layout.thumbPosition}>
-            <MinimapThumbnail scale={0.5} />
-          </Billboard>
-        </group>
-      )}
     </group>
   );
 };

--- a/components/MinimapOverlay.tsx
+++ b/components/MinimapOverlay.tsx
@@ -37,21 +37,19 @@ const MAP_LAYOUT: Record<CameraTarget, {
 
 type MinimapOverlayProps = {
   cameraPosition: CameraTarget;
-  showMap: boolean;
   minimapState: MinimapState;
   setMinimapState: MinimapStateSetter;
 };
 
 const MinimapOverlay = ({
   cameraPosition,
-  showMap,
   minimapState,
   setMinimapState,
 }: MinimapOverlayProps) => {
   const layout = useMemo(() => MAP_LAYOUT[cameraPosition], [cameraPosition]);
 
   const { autoPilot, triggered } = minimapState;
-  const shouldResetPosition = triggered || !showMap || !autoPilot;
+  const shouldResetPosition = triggered || !autoPilot;
   const mapPosition = shouldResetPosition ? DEFAULT_MAP_POSITION : layout.mapPosition;
   const lightPosition = shouldResetPosition ? DEFAULT_LIGHT_POSITION : layout.lightPosition;
 

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+import * as React from 'react';
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+
+import { cn } from '../../lib/utils';
+
+const Dialog = DialogPrimitive.Root;
+
+const DialogTrigger = DialogPrimitive.Trigger;
+
+const DialogPortal = DialogPrimitive.Portal;
+
+const DialogOverlay = React.forwardRef<React.ElementRef<typeof DialogPrimitive.Overlay>, React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>>(
+  ({ className, ...props }, ref) => (
+    <DialogPrimitive.Overlay
+      ref={ref}
+      className={cn(
+        'fixed inset-0 z-50 bg-black/70 backdrop-blur-sm transition-opacity data-[state=closed]:animate-out data-[state=open]:animate-in data-[state=closed]:fade-out data-[state=open]:fade-in',
+        className,
+      )}
+      {...props}
+    />
+  ),
+);
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
+
+const DialogContent = React.forwardRef<React.ElementRef<typeof DialogPrimitive.Content>, React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>>(
+  ({ className, children, ...props }, ref) => (
+    <DialogPortal>
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        ref={ref}
+        className={cn(
+          'fixed left-1/2 top-1/2 z-50 grid w-[min(520px,90vw)] max-h-[85vh] translate-x-[-50%] translate-y-[-50%] gap-6 rounded-2xl border border-white/10 bg-neutral-900/95 p-6 text-white shadow-xl outline-none focus-visible:ring-2 focus-visible:ring-orange-400',
+          className,
+        )}
+        {...props}
+      >
+        {children}
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  ),
+);
+DialogContent.displayName = DialogPrimitive.Content.displayName;
+
+const DialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn('flex flex-col gap-2 text-left', className)} {...props} />
+);
+DialogHeader.displayName = 'DialogHeader';
+
+const DialogTitle = React.forwardRef<React.ElementRef<typeof DialogPrimitive.Title>, React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>>(
+  ({ className, ...props }, ref) => (
+    <DialogPrimitive.Title
+      ref={ref}
+      className={cn('text-xl font-semibold text-white', className)}
+      {...props}
+    />
+  ),
+);
+DialogTitle.displayName = DialogPrimitive.Title.displayName;
+
+const DialogDescription = React.forwardRef<React.ElementRef<typeof DialogPrimitive.Description>, React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>>(
+  ({ className, ...props }, ref) => (
+    <DialogPrimitive.Description
+      ref={ref}
+      className={cn('text-sm leading-relaxed text-white/80', className)}
+      {...props}
+    />
+  ),
+);
+DialogDescription.displayName = DialogPrimitive.Description.displayName;
+
+const DialogFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn('flex flex-col-reverse gap-2 sm:flex-row sm:justify-end', className)} {...props} />
+);
+DialogFooter.displayName = 'DialogFooter';
+
+const DialogClose = DialogPrimitive.Close;
+
+export {
+  Dialog,
+  DialogTrigger,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+  DialogClose,
+};

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,0 +1,3 @@
+export function cn(...classes: Array<string | false | null | undefined>) {
+  return classes.filter(Boolean).join(' ');
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "homepage",
       "version": "0.1.0",
       "dependencies": {
+        "@radix-ui/react-dialog": "^1.1.15",
         "@react-three/drei": "10.7.6",
         "@react-three/fiber": "9.4.0",
         "next": "^15.5.6",
@@ -1240,6 +1241,337 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@radix-ui/primitive": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
+      "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+      "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.15.tgz",
+      "integrity": "sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.11.tgz",
+      "integrity": "sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-escape-keydown": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-guards": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.3.tgz",
+      "integrity": "sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-scope": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.7.tgz",
+      "integrity": "sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-id": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.1.tgz",
+      "integrity": "sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-portal": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.9.tgz",
+      "integrity": "sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-presence": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.5.tgz",
+      "integrity": "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.1.tgz",
+      "integrity": "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz",
+      "integrity": "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-effect-event": "0.0.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.2.tgz",
+      "integrity": "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-escape-keydown": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.1.tgz",
+      "integrity": "sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-callback-ref": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
+      "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@react-three/drei": {
       "version": "10.7.6",
       "resolved": "https://registry.npmjs.org/@react-three/drei/-/drei-10.7.6.tgz",
@@ -1716,7 +2048,7 @@
       "version": "19.2.2",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.2.tgz",
       "integrity": "sha512-9KQPoO6mZCi7jcIStSnlOWn2nEF3mNmyr3rIAsGnAbQKYbRLyqmeSc39EVgtxXVia+LMT8j3knZLAZAh+xLmrw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -2394,6 +2726,18 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/aria-hidden": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
+      "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/aria-query": {
       "version": "5.3.2",
@@ -3139,6 +3483,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/detect-node-es": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+      "license": "MIT"
     },
     "node_modules/draco3d": {
       "version": "1.5.7",
@@ -4139,6 +4489,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-nonce": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/get-proto": {
@@ -7228,6 +7587,75 @@
         "react": "^19.0.0"
       }
     },
+    "node_modules/react-remove-scroll": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.1.tgz",
+      "integrity": "sha512-HpMh8+oahmIdOuS5aFKKY6Pyog+FNaZV/XyJOq7b4YFwsFHe5yYfdbIalI4k3vU2nSDql7YskmUseHsRrJqIPA==",
+      "license": "MIT",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.7",
+        "react-style-singleton": "^2.2.3",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.3",
+        "use-sidecar": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-remove-scroll-bar": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
+      "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-style-singleton": "^2.2.2",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-style-singleton": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
+      "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "get-nonce": "^1.0.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-use-measure": {
       "version": "2.1.7",
       "resolved": "https://registry.npmjs.org/react-use-measure/-/react-use-measure-2.1.7.tgz",
@@ -8588,6 +9016,49 @@
         "requires-port": "^1.0.0"
       }
     },
+    "node_modules/use-callback-ref": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+      "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-sidecar": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
+      "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-node-es": "^1.1.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/use-sync-external-store": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
@@ -9527,6 +9998,151 @@
       "integrity": "sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==",
       "dev": true
     },
+    "@radix-ui/primitive": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
+      "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg=="
+    },
+    "@radix-ui/react-compose-refs": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+      "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+      "requires": {}
+    },
+    "@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "requires": {}
+    },
+    "@radix-ui/react-dialog": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.15.tgz",
+      "integrity": "sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==",
+      "requires": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      }
+    },
+    "@radix-ui/react-dismissable-layer": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.11.tgz",
+      "integrity": "sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==",
+      "requires": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-escape-keydown": "1.1.1"
+      }
+    },
+    "@radix-ui/react-focus-guards": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.3.tgz",
+      "integrity": "sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==",
+      "requires": {}
+    },
+    "@radix-ui/react-focus-scope": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.7.tgz",
+      "integrity": "sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==",
+      "requires": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1"
+      }
+    },
+    "@radix-ui/react-id": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.1.tgz",
+      "integrity": "sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==",
+      "requires": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      }
+    },
+    "@radix-ui/react-portal": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.9.tgz",
+      "integrity": "sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==",
+      "requires": {
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      }
+    },
+    "@radix-ui/react-presence": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.5.tgz",
+      "integrity": "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==",
+      "requires": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      }
+    },
+    "@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "requires": {
+        "@radix-ui/react-slot": "1.2.3"
+      }
+    },
+    "@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "requires": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      }
+    },
+    "@radix-ui/react-use-callback-ref": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.1.tgz",
+      "integrity": "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==",
+      "requires": {}
+    },
+    "@radix-ui/react-use-controllable-state": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz",
+      "integrity": "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==",
+      "requires": {
+        "@radix-ui/react-use-effect-event": "0.0.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      }
+    },
+    "@radix-ui/react-use-effect-event": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.2.tgz",
+      "integrity": "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==",
+      "requires": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      }
+    },
+    "@radix-ui/react-use-escape-keydown": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.1.tgz",
+      "integrity": "sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==",
+      "requires": {
+        "@radix-ui/react-use-callback-ref": "1.1.1"
+      }
+    },
+    "@radix-ui/react-use-layout-effect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
+      "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
+      "requires": {}
+    },
     "@react-three/drei": {
       "version": "10.7.6",
       "resolved": "https://registry.npmjs.org/@react-three/drei/-/drei-10.7.6.tgz",
@@ -9812,7 +10428,7 @@
       "version": "19.2.2",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.2.tgz",
       "integrity": "sha512-9KQPoO6mZCi7jcIStSnlOWn2nEF3mNmyr3rIAsGnAbQKYbRLyqmeSc39EVgtxXVia+LMT8j3knZLAZAh+xLmrw==",
-      "dev": true,
+      "devOptional": true,
       "requires": {}
     },
     "@types/react-reconciler": {
@@ -10198,6 +10814,14 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
+    },
+    "aria-hidden": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
+      "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
+      "requires": {
+        "tslib": "^2.0.0"
+      }
     },
     "aria-query": {
       "version": "5.3.2",
@@ -10686,6 +11310,11 @@
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "devOptional": true
+    },
+    "detect-node-es": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="
     },
     "draco3d": {
       "version": "1.5.7",
@@ -11402,6 +12031,11 @@
         "hasown": "^2.0.2",
         "math-intrinsics": "^1.1.0"
       }
+    },
+    "get-nonce": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q=="
     },
     "get-proto": {
       "version": "1.0.1",
@@ -13187,6 +13821,36 @@
         "scheduler": "^0.25.0"
       }
     },
+    "react-remove-scroll": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.1.tgz",
+      "integrity": "sha512-HpMh8+oahmIdOuS5aFKKY6Pyog+FNaZV/XyJOq7b4YFwsFHe5yYfdbIalI4k3vU2nSDql7YskmUseHsRrJqIPA==",
+      "requires": {
+        "react-remove-scroll-bar": "^2.3.7",
+        "react-style-singleton": "^2.2.3",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.3",
+        "use-sidecar": "^1.1.3"
+      }
+    },
+    "react-remove-scroll-bar": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
+      "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
+      "requires": {
+        "react-style-singleton": "^2.2.2",
+        "tslib": "^2.0.0"
+      }
+    },
+    "react-style-singleton": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
+      "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
+      "requires": {
+        "get-nonce": "^1.0.0",
+        "tslib": "^2.0.0"
+      }
+    },
     "react-use-measure": {
       "version": "2.1.7",
       "resolved": "https://registry.npmjs.org/react-use-measure/-/react-use-measure-2.1.7.tgz",
@@ -14094,6 +14758,23 @@
       "requires": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
+      }
+    },
+    "use-callback-ref": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+      "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
+      "requires": {
+        "tslib": "^2.0.0"
+      }
+    },
+    "use-sidecar": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
+      "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
+      "requires": {
+        "detect-node-es": "^1.1.0",
+        "tslib": "^2.0.0"
       }
     },
     "use-sync-external-store": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@radix-ui/react-dialog": "^1.1.15",
     "@react-three/drei": "10.7.6",
     "@react-three/fiber": "9.4.0",
     "next": "^15.5.6",


### PR DESCRIPTION
## Summary
- replace the 3D text-based minimap toggle instructions with a reusable help dialog overlay
- add a minimap help button with shadcn dialog styling and a live minimap preview canvas
- expose a UI toggle for the minimap and auto-dismiss the dialog after the first location jump

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68fb57a3d2e8832887b7c1fbceadc047